### PR TITLE
fix:clipboard mock should return a promise in siteInfoPage test

### DIFF
--- a/src/pages/siteInfo/siteInfoPage.test.js
+++ b/src/pages/siteInfo/siteInfoPage.test.js
@@ -6,9 +6,9 @@ import { QDRService } from "../../qdrService";
 const service = new QDRService();
 
 test("renders site info page", () => {
-  Object.defineProperty(navigator, "clipboard", {
-    value: {
-      readText: jest.fn(),
+  Object.assign(navigator, {
+    clipboard: {
+      readText: () => Promise.resolve(jest.fn()),
     },
   });
   const setOptions = jest.fn();


### PR DESCRIPTION
We need to mock the window object navigator.clipboard.readText as a Promise instead of a function.
https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText